### PR TITLE
Github Actions

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         compiler_version: [9]
-        python-version: [3.10]
+        python-version: ['3.10']
 
     steps:
       - uses: actions/checkout@v3
@@ -80,7 +80,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-2019]
-        python-version: [3.10]
+        python-version: ['3.10']
 
     steps:
       - uses: actions/checkout@v3
@@ -116,7 +116,7 @@ jobs:
 #      fail-fast: false
 #      matrix:
 #        os: [macos-11]
-#        python-version: [3.10]
+#        python-version: ['3.10']
 #
 #    steps:
 #      - uses: actions/checkout@v3

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -1,0 +1,116 @@
+
+name: Build
+
+on: [push, workflow_dispatch]
+
+jobs:
+  conan-on-linux:
+
+    runs-on: ${{ matrix.os }}
+    env:
+      CC: gcc-${{ matrix.compiler_version }}
+      CXX: g++-${{ matrix.compiler_version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04]
+        compiler_version: [9]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install prerequisites
+        run: |
+          sudo apt install -y \
+          libgtk2.0-dev \
+          libva-dev \
+          libvdpau-dev \
+          libx11-xcb-dev \
+          libfontenc-dev \
+          libxaw7-dev \libxkbfile-dev \
+          libxmu-dev \
+          libxmuu-dev \
+          libxpm-dev \
+          libxres-dev \
+          libxss-dev \
+          libxtst-dev \
+          libxv-dev \
+          libxvmc-dev \
+          libxxf86vm-dev \
+          libxcb-render-util0-dev \
+          libxcb-xkb-dev \
+          libxcb-icccm4-dev \
+          libxcb-image0-dev \
+          libxcb-keysyms1-dev \
+          libxcb-randr0-dev \
+          libxcb-shape0-dev \
+          libxcb-sync-dev \
+          libxcb-xfixes0-dev \
+          libxcb-xinerama0-dev \
+          libxcb-dri3-dev \
+          libxcb-util-dev \
+          libxcb-util0-dev
+          sudo pip3 install conan
+      - name: Run conan
+        run: |
+          conan install . -s build_type=Release -if build -b missing
+      - name: Configure and build
+        run: |
+          cmake . -B build -DCMAKE_BUILD_TYPE=Release
+          cmake --build build
+      - name: Archive Python link library
+        uses: actions/upload-artifact@v3
+        with:
+          name: python-link-library
+          path: build/lib/CosmoSimPy.*.so
+
+
+  conan-on-windows:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-2019]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install prerequisites
+        run: |
+          pip3 install conan
+      - name: Run conan
+        run: |
+          conan install . -s build_type=Release -if build -b missing
+      - name: Configure and build
+        run: |
+          cmake . -A x64 -B build -DCMAKE_BUILD_TYPE=Release
+          cmake --build build --config Release
+      - name: Archive Python link library
+        uses: actions/upload-artifact@v3
+        with:
+          name: python-link-library
+          path: build/lib/CosmoSimPy.*.pyd
+
+
+  conan-on-darwin:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-11]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install prerequisites
+        run: |
+          pip3 install conan
+      - name: Run conan
+        run: |
+          conan install . -s build_type=Release -if build -b missing
+      - name: Configure and build
+        run: |
+          cmake . -B build -DCMAKE_BUILD_TYPE=Release
+          cmake --build build

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -15,9 +15,16 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         compiler_version: [9]
+        python-version: [3.10]
 
     steps:
       - uses: actions/checkout@v3
+
+      - name: Setup Python 3.x
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: 'x64'
 
       - name: Install prerequisites
         run: |
@@ -58,6 +65,7 @@ jobs:
         run: |
           cmake . -B build -DCMAKE_BUILD_TYPE=Release
           cmake --build build
+
       - name: Archive Python link library
         uses: actions/upload-artifact@v3
         with:
@@ -72,9 +80,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-2019]
+        python-version: [3.10]
 
     steps:
       - uses: actions/checkout@v3
+
+      - name: Setup Python 3.x
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: 'x64'
 
       - name: Install prerequisites
         run: |
@@ -86,6 +101,7 @@ jobs:
         run: |
           cmake . -A x64 -B build -DCMAKE_BUILD_TYPE=Release
           cmake --build build --config Release
+
       - name: Archive Python link library
         uses: actions/upload-artifact@v3
         with:
@@ -93,24 +109,37 @@ jobs:
           path: build/lib/CosmoSimPy.*.pyd
 
 
-  conan-on-darwin:
-
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-11]
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Install prerequisites
-        run: |
-          pip3 install conan
-      - name: Run conan
-        run: |
-          conan install . -s build_type=Release -if build -b missing
-      - name: Configure and build
-        run: |
-          cmake . -B build -DCMAKE_BUILD_TYPE=Release
-          cmake --build build
+#  conan-on-darwin:
+#
+#    runs-on: ${{ matrix.os }}
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        os: [macos-11]
+#        python-version: [3.10]
+#
+#    steps:
+#      - uses: actions/checkout@v3
+#
+#      - name: Setup Python 3.x
+#        uses: actions/setup-python@v4
+#        with:
+#          python-version: ${{ matrix.python-version }}
+#          architecture: 'x64'
+#
+#      - name: Install prerequisites
+#        run: |
+#          pip3 install conan
+#      - name: Run conan
+#        run: |
+#          conan install . -s build_type=Release -if build -b missing
+#      - name: Configure and build
+#        run: |
+#          cmake . -B build -DCMAKE_BUILD_TYPE=Release
+#          cmake --build build
+#
+#      - name: Archive Python link library
+#        uses: actions/upload-artifact@v3
+#        with:
+#          name: python-link-library
+#          path: build/lib/CosmoSimPy.*


### PR DESCRIPTION
Enable GitHUb actions that builds the native library and uploads the python link libraries.
The runner builds for Python 3.10. We could expand on that.

Note that I've deactivated Darwin platform as it takes forever to build on the runner, even though that was the main goal...